### PR TITLE
Use xdg-open from PATH instead of hardcoded.

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -21,6 +21,6 @@ func (o *LinuxOpener) Open(u string, windowType WindowType, autoRaise bool) erro
 	if getEnv("DISPLAY", o.Env) == "" {
 		return &RequireXError{}
 	}
-	cmd := exec.Command("/usr/bin/xdg-open", u)
+	cmd := exec.Command("xdg-open", u)
 	return cmd.Run()
 }


### PR DESCRIPTION
This broke any system that install `xdg-open` something else (like NixOS).

Signed-off-by: Vincent Demeester <vincent@sbr.pm>